### PR TITLE
Standardization of the "Light pet" item type.

### DIFF
--- a/json/id_references/items.json
+++ b/json/id_references/items.json
@@ -572,7 +572,7 @@
     {
         "ID": "115",
         "Name": "Shadow Orb (item)",
-        "Type": "Light Pet"
+        "Type": "Light pet"
     },
     {
         "ID": "116",
@@ -15307,7 +15307,7 @@
     {
         "ID": "3062",
         "Name": "Crimson Heart (item)",
-        "Type": "Light Pet"
+        "Type": "Light pet"
     },
     {
         "ID": "3063",


### PR DESCRIPTION
Two of the object types were not typed in the same way as the others (presence of capital letters).